### PR TITLE
Quote version used in prereqsfile example

### DIFF
--- a/lib/Dist/Zilla/Plugin/PrereqsFile.pm
+++ b/lib/Dist/Zilla/Plugin/PrereqsFile.pm
@@ -56,7 +56,7 @@ __PACKAGE__->meta->make_immutable;
 
  runtime:
    recommends:
-     Foo: 0.023
+     Foo: '0.023'
    suggests:
      Bar: 0
 


### PR DESCRIPTION
It's good practice to treat any (nonzero) versions explicitly as strings. This is probably more important with any versions with v or underscore as I have no idea how YAML would treat those.